### PR TITLE
👷chore: update `.gitignore` to exclude specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IGNORE DIRECTORY
 # IGNORE FILE
-app/presentation/cli/cli
+app/presentation/cli/mindnum/mindnum
+main
 .DS_Store
 *.log


### PR DESCRIPTION
- ignore the `mindnum` binary in the CLI presentation
- exclude the `main` binary in the root directory