### PR TITLE
🐞fix: improve version retrieval logic with empty main version

### DIFF
--- a/app/application/mindnum/get_mindnum_usecase.go
+++ b/app/application/mindnum/get_mindnum_usecase.go
@@ -4,10 +4,12 @@ import (
 	mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
 )
 
+// GetMindnumUseCase is a struct that provides the use case of getting a mind number.
 type GetMindnumUseCase struct {
 	mindnumRepo mindnumDomain.MindnumRepository
 }
 
+// NewGetMindnumUseCase returns a new instance of the GetMindnumUseCase struct.
 func NewGetMindnumUseCase(
 	mindnumRepo mindnumDomain.MindnumRepository,
 ) *GetMindnumUseCase {
@@ -16,11 +18,13 @@ func NewGetMindnumUseCase(
 	}
 }
 
+// GetMindnumUsecaseOutputDto is a struct that provides the output DTO of the GetMindnumUseCase struct.
 type GetMindnumUsecaseOutputDto struct {
 	MindNumber  int
 	Description string
 }
 
+// Run returns the output of the GetMindnumUseCase struct.
 func (uc *GetMindnumUseCase) Run(birthday string) (*GetMindnumUsecaseOutputDto, error) {
 	mindNumber, err := mindnumDomain.GetMindNumber(birthday)
 	if err != nil {

--- a/app/application/mindnum/version_usecase.go
+++ b/app/application/mindnum/version_usecase.go
@@ -2,16 +2,20 @@ package mindnum
 
 import ()
 
+// VersionUseCase is a struct that contains the use case of the version.
 type VersionUseCase struct{}
 
+// NewVersionUseCase returns a new instance of the VersionUseCase struct.
 func NewVersionUseCase() *VersionUseCase {
 	return &VersionUseCase{}
 }
 
+// VersionUsecaseOutputDto is a DTO struct that contains the output data of the VersionUseCase.
 type VersionUsecaseOutputDto struct {
 	Version string
 }
 
+// Run returns the output of the VersionUseCase.
 func (uc *VersionUseCase) Run(version string) *VersionUsecaseOutputDto {
 	return &VersionUsecaseOutputDto{
 		Version: version,

--- a/app/domain/mindnum/mindnum_model.go
+++ b/app/domain/mindnum/mindnum_model.go
@@ -8,11 +8,13 @@ import (
 	"github.com/yanosea/mindnum/pkg/errors"
 )
 
+// Mindnum is a struct that represents a mind number and its description.
 type Mindnum struct {
 	MindNumber  int
 	Description string
 }
 
+// NewMindnum returns a new instance of the Mindnum struct.
 func NewMindnum(mindNumber int, description string) (*Mindnum, error) {
 	if mindNumber < 1 || 9 < mindNumber {
 		return nil, errors.New("mind number out of range")
@@ -23,6 +25,7 @@ func NewMindnum(mindNumber int, description string) (*Mindnum, error) {
 	}, nil
 }
 
+// GetMindNumber returns a mind number from a birthday.
 func GetMindNumber(birthday string) (int, error) {
 	if birthday == "" {
 		return 0, errors.New("birthday is required")

--- a/app/domain/mindnum/mindnum_repository.go
+++ b/app/domain/mindnum/mindnum_repository.go
@@ -2,6 +2,7 @@ package mindnum
 
 import ()
 
+// MindnumRepository is an interface that provides the repository of the mindnum.
 type MindnumRepository interface {
 	FindByNumber(number int) (*Mindnum, error)
 }

--- a/app/infrastructure/text/repository/mindnum_descriptions.go
+++ b/app/infrastructure/text/repository/mindnum_descriptions.go
@@ -1,6 +1,7 @@
 package repository
 
 const (
+	// DescriptionOne is a description of the mindnum number one.
 	DescriptionOne = `You are a CHALLENGER 💪
 
 CHALLENGER is like...
@@ -11,6 +12,7 @@ Stiff ideas, such as repeating the same job day after day and relationships that
 You are an "upstart" type who fulfills your dreams through your abilities.
 It is important to find "my style" without fear of failure and always remember to challenge yourself.
 `
+	// DescriptionTwo is a description of the mindnum number two.
 	DescriptionTwo = `You are a MAGICIAN 🎩
 
 MAGICIAN is like...
@@ -25,6 +27,7 @@ you may receive a confession of love from that person.
 Since you have the power to make things happen, it is important to keep a happy mindset on a daily basis,
 as you will attract bad things if you only think about negative things on a regular basis.
 `
+	// DescriptionThree is a description of the mindnum number three.
 	DescriptionThree = `You are a TEACHER 📚
 
 TEACHER is like...
@@ -37,6 +40,7 @@ you are more suited to timeless pieces such as high quality, antique, and handma
 Perfectionists and stoics, they are the type who feel uncomfortable unless they do everything themselves.
 Be careful not to set your ideals too high, as you will shut others down.
 `
+	// DescriptionFour is a description of the mindnum number four.
 	DescriptionFour = `You are a QUEEN 🪄
 
 QUEEN is like...
@@ -51,6 +55,7 @@ You are also blessed with position, power, and money,
 and there are many entrepreneurs and successful people who are on the top of the ladder.
 You are an empress, so don't hold back or worry about what people think of you.
 `
+	// DescriptionFive is a description of the mindnum number five.
 	DescriptionFive = `You are a KING 👑
 
 KING is like...
@@ -65,6 +70,7 @@ You will take action based on your strong belief that "I am me."
 It is important for you to follow your heart rather than listening to the words of those around you.
 There is no dream that you cannot achieve.
 `
+	// DescriptionSix is a description of the mindnum number six.
 	DescriptionSix = `You are a MESSENGER 📬
 
 MESSENGER is like...
@@ -78,6 +84,7 @@ However, you are also a perfectionist and impose your own rules on those around 
 If you think too much about the people around you, you get stuck and your mind gets tired.
 Sometimes it is important to move as you please without thinking about those around you.
 `
+	// DescriptionSeven is a description of the mindnum number seven.
 	DescriptionSeven = `You are a LOVER 💖
 
 LOVER is like...
@@ -89,6 +96,7 @@ On the other hand, when you are in love, you are invincible.
 Your aura shines brightly and you become more and more attractive.
 By nurturing your love, you will be able to achieve even greater happiness.
 `
+	// DescriptionEight is a description of the mindnum number eight.
 	DescriptionEight = `You are a FIGHTER 🥊
 
 FIGHTER is like...
@@ -101,6 +109,7 @@ Because he stubbornly never changes his opinions, he is often misunderstood by t
 You also prefer to work in small groups rather than in groups, as you feel comfortable working alone.
 It is your intuition and unfounded confidence that will lead you to success.
 `
+	// DescriptionNine is a description of the mindnum number nine.
 	DescriptionNine = `You are a BALANCER ⚖️
 
 BALANCER is like...

--- a/app/infrastructure/text/repository/mindnum_repository.go
+++ b/app/infrastructure/text/repository/mindnum_repository.go
@@ -6,12 +6,15 @@ import (
 	"github.com/yanosea/mindnum/pkg/errors"
 )
 
+// mindnumRepository is a struct that implements the MindnumRepository interface.
 type mindnumRepository struct{}
 
+// NewMindnumRepository returns a new instance of the mindnumRepository struct.
 func NewMindnumRepository() mindnumDomain.MindnumRepository {
 	return &mindnumRepository{}
 }
 
+// FindByNumber returns a mindnum by number.
 func (r *mindnumRepository) FindByNumber(number int) (*mindnumDomain.Mindnum, error) {
 	var description string
 	switch number {

--- a/app/presentation/cli/mindnum/command/command.go
+++ b/app/presentation/cli/mindnum/command/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// Cli is a struct that represents the command line interface of mindnum cli.
 type Cli struct {
 	Cobra       proxy.Cobra
 	Version     string
@@ -16,10 +17,13 @@ type Cli struct {
 }
 
 var (
+	// output is the output string
 	output string
+	// format is the format of the output
 	format = "text"
 )
 
+// NewCli returns a new instance of the Cli struct.
 func NewCli(
 	cobra proxy.Cobra,
 	version string,
@@ -32,6 +36,7 @@ func NewCli(
 	}
 }
 
+// Run runs the command line interface of mindnum cli.
 func (c *Cli) Run() int {
 	out := os.Stdout
 	exitCode := 0

--- a/app/presentation/cli/mindnum/command/mindnum/get.go
+++ b/app/presentation/cli/mindnum/command/mindnum/get.go
@@ -11,9 +11,11 @@ import (
 )
 
 var (
+	// birthday is the receiver of the birthday flag
 	birthday string
 )
 
+// NewGetCommand returns a new instance of the get command.
 func NewGetCommand(
 	cobra proxy.Cobra,
 	format *string,
@@ -40,6 +42,7 @@ func NewGetCommand(
 	return cmd
 }
 
+// runGet runs the get command.
 func runGet(birthday *string, format *string, output *string, args []string) error {
 	if len(args) > 0 {
 		*birthday = args[0]
@@ -65,9 +68,11 @@ func runGet(birthday *string, format *string, output *string, args []string) err
 }
 
 const (
+	// getHelpTemplate is the help template of the get command.
 	getHelpTemplate = `🧠 Get a mind number from an argument or the birthday flag and show the personality description
 
 ` + getUsageTemplate
+	// getUsageTemplate is the usage template of the get command.
 	getUsageTemplate = `Usage:
   mindnum get [birthday (optional)] [flags]
 

--- a/app/presentation/cli/mindnum/command/mindnum/version.go
+++ b/app/presentation/cli/mindnum/command/mindnum/version.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// NewVersionCommand returns a new instance of the version command.
 func NewVersionCommand(
 	cobra proxy.Cobra,
 	version string,
@@ -30,6 +31,7 @@ func NewVersionCommand(
 	return cmd
 }
 
+// runVersion runs the version command.
 func runVersion(version string, format *string, output *string) error {
 	uc := mindnumApp.NewVersionUseCase()
 	dto := uc.Run(version)
@@ -47,9 +49,11 @@ func runVersion(version string, format *string, output *string) error {
 }
 
 const (
+	// versionHelpTemplate is the help template of the version command.
 	versionHelpTemplate = `🔖 Show the version of mindnum
 
 ` + versionUsageTemplate
+	// versionUsageTemplate is the usage template of the version command.
 	versionUsageTemplate = `Usage:
   mindnum version [flags]
 

--- a/app/presentation/cli/mindnum/command/root.go
+++ b/app/presentation/cli/mindnum/command/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// NewRootCommand returns a new instance of the root command.
 func NewRootCommand(
 	cobra proxy.Cobra,
 	version string,
@@ -36,9 +37,11 @@ func NewRootCommand(
 }
 
 const (
+	// rootHelpTemplate is the help template of the root command.
 	rootHelpTemplate = `🧠 mindnum is a CLI tool to get the mind number from the birthday
 
 ` + rootUsageTemplate
+	// rootUsageTemplate is the usage template of the root command.
 	rootUsageTemplate = `Usage:
   mindnum [command]
 

--- a/app/presentation/cli/mindnum/formatter/color.go
+++ b/app/presentation/cli/mindnum/formatter/color.go
@@ -5,6 +5,8 @@ import (
 )
 
 var (
+	// Green is a proxy of fatih/color.Green.
 	Green = color.New(color.FgGreen).SprintFunc()
-	Red   = color.New(color.FgRed).SprintFunc()
+	// Red is a proxy of fatih/color.Red.
+	Red = color.New(color.FgRed).SprintFunc()
 )

--- a/app/presentation/cli/mindnum/formatter/formatter.go
+++ b/app/presentation/cli/mindnum/formatter/formatter.go
@@ -6,10 +6,12 @@ import (
 	"github.com/yanosea/mindnum/pkg/errors"
 )
 
+// Formatter is an interface that formats the output of mindnum cli.
 type Formatter interface {
 	Format(result interface{}) string
 }
 
+// NewFormatter returns a new instance of the Formatter interface.
 func NewFormatter(
 	format string,
 ) (Formatter, error) {
@@ -23,6 +25,7 @@ func NewFormatter(
 	return f, nil
 }
 
+// AppendErrorToOutput appends an error to the output.
 func AppendErrorToOutput(err error, output string) string {
 	if err == nil && output == "" {
 		return ""

--- a/app/presentation/cli/mindnum/formatter/text.go
+++ b/app/presentation/cli/mindnum/formatter/text.go
@@ -7,12 +7,15 @@ import (
 	mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
 )
 
+// TextFormatter is a struct that formats the output of mindnum cli.
 type TextFormatter struct{}
 
+// NewTextFormatter returns a new instance of the TextFormatter struct.
 func NewTextFormatter() *TextFormatter {
 	return &TextFormatter{}
 }
 
+// Format formats the output of mindnum cli.
 func (f *TextFormatter) Format(result interface{}) string {
 	var formatted string
 	switch v := result.(type) {

--- a/app/presentation/cli/mindnum/main.go
+++ b/app/presentation/cli/mindnum/main.go
@@ -10,12 +10,17 @@ import (
 )
 
 var (
-	version     = ""
-	cobra       = proxy.NewCobra()
+	// version is the version of mindnum cli.
+	version = ""
+	// cobra is a proxy of spf13/cobra.
+	cobra = proxy.NewCobra()
+	// versionUtil is a provider of the version of the application.
 	versionUtil = utility.NewVersionUtil(proxy.NewDebug())
-	exit        = os.Exit
+	// exit is a proxy of os.Exit.
+	exit = os.Exit
 )
 
+// main is the entry point of mindnum cli.
 func main() {
 	cli := command.NewCli(
 		cobra,

--- a/app/presentation/cli/mindnum/main_test.go
+++ b/app/presentation/cli/mindnum/main_test.go
@@ -24,7 +24,7 @@ func Test_main(t *testing.T) {
 
 	type fields struct {
 		fnc      func()
-		capturer *utility.Capturer
+		capturer utility.Capturable
 	}
 	tests := []struct {
 		name       string

--- a/app/presentation/cli/mindnum/presenter/mindnum_presenter.go
+++ b/app/presentation/cli/mindnum/presenter/mindnum_presenter.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// Present is a function that writes the output to the writer.
 func Present(writer io.Writer, output string) {
 	if output != "" {
 		fmt.Fprintf(writer, "%s\n", output)

--- a/app/presentation/cli/mindnum/presenter/mindnum_presenter_test.go
+++ b/app/presentation/cli/mindnum/presenter/mindnum_presenter_test.go
@@ -16,7 +16,7 @@ func TestPresent(t *testing.T) {
 
 	type fields struct {
 		fnc      func()
-		capturer *utility.Capturer
+		capturer utility.Capturable
 	}
 	tests := []struct {
 		name       string

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -103,10 +103,12 @@ import (
         mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
 )
 
+// GetMindnumUseCase is a struct that provides the use case of getting a mind number.
 type GetMindnumUseCase struct {
         mindnumRepo mindnumDomain.MindnumRepository
 }
 
+// NewGetMindnumUseCase returns a new instance of the GetMindnumUseCase struct.
 func NewGetMindnumUseCase(
         mindnumRepo mindnumDomain.MindnumRepository,
 ) *GetMindnumUseCase <span class="cov8" title="1">{
@@ -115,11 +117,13 @@ func NewGetMindnumUseCase(
         }
 }</span>
 
+// GetMindnumUsecaseOutputDto is a struct that provides the output DTO of the GetMindnumUseCase struct.
 type GetMindnumUsecaseOutputDto struct {
         MindNumber  int
         Description string
 }
 
+// Run returns the output of the GetMindnumUseCase struct.
 func (uc *GetMindnumUseCase) Run(birthday string) (*GetMindnumUsecaseOutputDto, error) <span class="cov8" title="1">{
         mindNumber, err := mindnumDomain.GetMindNumber(birthday)
         if err != nil </span><span class="cov8" title="1">{
@@ -142,16 +146,20 @@ func (uc *GetMindnumUseCase) Run(birthday string) (*GetMindnumUsecaseOutputDto, 
 
 import ()
 
+// VersionUseCase is a struct that contains the use case of the version.
 type VersionUseCase struct{}
 
+// NewVersionUseCase returns a new instance of the VersionUseCase struct.
 func NewVersionUseCase() *VersionUseCase <span class="cov8" title="1">{
         return &amp;VersionUseCase{}
 }</span>
 
+// VersionUsecaseOutputDto is a DTO struct that contains the output data of the VersionUseCase.
 type VersionUsecaseOutputDto struct {
         Version string
 }
 
+// Run returns the output of the VersionUseCase.
 func (uc *VersionUseCase) Run(version string) *VersionUsecaseOutputDto <span class="cov8" title="1">{
         return &amp;VersionUsecaseOutputDto{
                 Version: version,
@@ -169,11 +177,13 @@ import (
         "github.com/yanosea/mindnum/pkg/errors"
 )
 
+// Mindnum is a struct that represents a mind number and its description.
 type Mindnum struct {
         MindNumber  int
         Description string
 }
 
+// NewMindnum returns a new instance of the Mindnum struct.
 func NewMindnum(mindNumber int, description string) (*Mindnum, error) <span class="cov8" title="1">{
         if mindNumber &lt; 1 || 9 &lt; mindNumber </span><span class="cov8" title="1">{
                 return nil, errors.New("mind number out of range")
@@ -184,6 +194,7 @@ func NewMindnum(mindNumber int, description string) (*Mindnum, error) <span clas
         }, nil</span>
 }
 
+// GetMindNumber returns a mind number from a birthday.
 func GetMindNumber(birthday string) (int, error) <span class="cov8" title="1">{
         if birthday == "" </span><span class="cov8" title="1">{
                 return 0, errors.New("birthday is required")
@@ -221,12 +232,15 @@ import (
         "github.com/yanosea/mindnum/pkg/errors"
 )
 
+// mindnumRepository is a struct that implements the MindnumRepository interface.
 type mindnumRepository struct{}
 
+// NewMindnumRepository returns a new instance of the mindnumRepository struct.
 func NewMindnumRepository() mindnumDomain.MindnumRepository <span class="cov8" title="1">{
         return &amp;mindnumRepository{}
 }</span>
 
+// FindByNumber returns a mindnum by number.
 func (r *mindnumRepository) FindByNumber(number int) (*mindnumDomain.Mindnum, error) <span class="cov8" title="1">{
         var description string
         switch number </span>{
@@ -267,6 +281,7 @@ import (
         "github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// Cli is a struct that represents the command line interface of mindnum cli.
 type Cli struct {
         Cobra       proxy.Cobra
         Version     string
@@ -274,10 +289,13 @@ type Cli struct {
 }
 
 var (
+        // output is the output string
         output string
+        // format is the format of the output
         format = "text"
 )
 
+// NewCli returns a new instance of the Cli struct.
 func NewCli(
         cobra proxy.Cobra,
         version string,
@@ -290,6 +308,7 @@ func NewCli(
         }
 }</span>
 
+// Run runs the command line interface of mindnum cli.
 func (c *Cli) Run() int <span class="cov8" title="1">{
         out := os.Stdout
         exitCode := 0
@@ -319,9 +338,11 @@ import (
 )
 
 var (
+        // birthday is the receiver of the birthday flag
         birthday string
 )
 
+// NewGetCommand returns a new instance of the get command.
 func NewGetCommand(
         cobra proxy.Cobra,
         format *string,
@@ -348,6 +369,7 @@ func NewGetCommand(
         <span class="cov8" title="1">return cmd</span>
 }
 
+// runGet runs the get command.
 func runGet(birthday *string, format *string, output *string, args []string) error <span class="cov8" title="1">{
         if len(args) &gt; 0 </span><span class="cov8" title="1">{
                 *birthday = args[0]
@@ -373,9 +395,11 @@ func runGet(birthday *string, format *string, output *string, args []string) err
 }
 
 const (
+        // getHelpTemplate is the help template of the get command.
         getHelpTemplate = `🧠 Get a mind number from an argument or the birthday flag and show the personality description
 
 ` + getUsageTemplate
+        // getUsageTemplate is the usage template of the get command.
         getUsageTemplate = `Usage:
   mindnum get [birthday (optional)] [flags]
 
@@ -400,6 +424,7 @@ import (
         "github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// NewVersionCommand returns a new instance of the version command.
 func NewVersionCommand(
         cobra proxy.Cobra,
         version string,
@@ -421,6 +446,7 @@ func NewVersionCommand(
         <span class="cov8" title="1">return cmd</span>
 }
 
+// runVersion runs the version command.
 func runVersion(version string, format *string, output *string) error <span class="cov8" title="1">{
         uc := mindnumApp.NewVersionUseCase()
         dto := uc.Run(version)
@@ -438,9 +464,11 @@ func runVersion(version string, format *string, output *string) error <span clas
 }
 
 const (
+        // versionHelpTemplate is the help template of the version command.
         versionHelpTemplate = `🔖 Show the version of mindnum
 
 ` + versionUsageTemplate
+        // versionUsageTemplate is the usage template of the version command.
         versionUsageTemplate = `Usage:
   mindnum version [flags]
 
@@ -458,6 +486,7 @@ import (
         "github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// NewRootCommand returns a new instance of the root command.
 func NewRootCommand(
         cobra proxy.Cobra,
         version string,
@@ -488,9 +517,11 @@ func NewRootCommand(
 }</span>
 
 const (
+        // rootHelpTemplate is the help template of the root command.
         rootHelpTemplate = `🧠 mindnum is a CLI tool to get the mind number from the birthday
 
 ` + rootUsageTemplate
+        // rootUsageTemplate is the usage template of the root command.
         rootUsageTemplate = `Usage:
   mindnum [command]
 
@@ -517,10 +548,12 @@ import (
         "github.com/yanosea/mindnum/pkg/errors"
 )
 
+// Formatter is an interface that formats the output of mindnum cli.
 type Formatter interface {
         Format(result interface{}) string
 }
 
+// NewFormatter returns a new instance of the Formatter interface.
 func NewFormatter(
         format string,
 ) (Formatter, error) <span class="cov8" title="1">{
@@ -534,6 +567,7 @@ func NewFormatter(
         <span class="cov8" title="1">return f, nil</span>
 }
 
+// AppendErrorToOutput appends an error to the output.
 func AppendErrorToOutput(err error, output string) string <span class="cov8" title="1">{
         if err == nil &amp;&amp; output == "" </span><span class="cov8" title="1">{
                 return ""
@@ -567,12 +601,15 @@ import (
         mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
 )
 
+// TextFormatter is a struct that formats the output of mindnum cli.
 type TextFormatter struct{}
 
+// NewTextFormatter returns a new instance of the TextFormatter struct.
 func NewTextFormatter() *TextFormatter <span class="cov8" title="1">{
         return &amp;TextFormatter{}
 }</span>
 
+// Format formats the output of mindnum cli.
 func (f *TextFormatter) Format(result interface{}) string <span class="cov8" title="1">{
         var formatted string
         switch v := result.(type) </span>{
@@ -604,12 +641,17 @@ import (
 )
 
 var (
-        version     = ""
-        cobra       = proxy.NewCobra()
+        // version is the version of mindnum cli.
+        version = ""
+        // cobra is a proxy of spf13/cobra.
+        cobra = proxy.NewCobra()
+        // versionUtil is a provider of the version of the application.
         versionUtil = utility.NewVersionUtil(proxy.NewDebug())
-        exit        = os.Exit
+        // exit is a proxy of os.Exit.
+        exit = os.Exit
 )
 
+// main is the entry point of mindnum cli.
 func main() <span class="cov8" title="1">{
         cli := command.NewCli(
                 cobra,
@@ -626,6 +668,7 @@ import (
         "io"
 )
 
+// Present is a function that writes the output to the writer.
 func Present(writer io.Writer, output string) <span class="cov8" title="1">{
         if output != "" </span><span class="cov8" title="1">{
                 fmt.Fprintf(writer, "%s\n", output)
@@ -637,11 +680,13 @@ func Present(writer io.Writer, output string) <span class="cov8" title="1">{
 
 import "fmt"
 
+// wrappedError is a struct that wraps an error and a message
 type wrappedError struct {
         err error
         msg string
 }
 
+// Error returns the error message formatted as a string
 func (e *wrappedError) Error() string <span class="cov8" title="1">{
         if e.err == nil &amp;&amp; e.msg == "" </span><span class="cov8" title="1">{
                 return ""
@@ -654,10 +699,12 @@ func (e *wrappedError) Error() string <span class="cov8" title="1">{
         }</span>
 }
 
+// New returns a new error with the given message
 func New(msg string) error <span class="cov8" title="1">{
         return &amp;wrappedError{msg: msg}
 }</span>
 
+// Wrap returns a new error that wraps the given error with the given message
 func Wrap(err error, msg string) error <span class="cov8" title="1">{
         return &amp;wrappedError{
                 err: err,
@@ -674,25 +721,32 @@ import (
         "github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// Capturable is an interface that captures the output of a function.
 type Capturable interface {
+        CaptureOutput(fnc func()) (string, string, error)
 }
 
-type Capturer struct {
+// capturer is a struct that implements the Capturable interface.
+type capturer struct {
+        // StdBuffer is a buffer for standard output.
         StdBuffer proxy.Buffer
+        // ErrBuffer is a buffer for error output.
         ErrBuffer proxy.Buffer
 }
 
+// NewCapturer returns a new instance of the capturer struct.
 func NewCapturer(
         sdtBuffer proxy.Buffer,
         errBuffer proxy.Buffer,
-) *Capturer <span class="cov8" title="1">{
-        return &amp;Capturer{
+) *capturer <span class="cov8" title="1">{
+        return &amp;capturer{
                 StdBuffer: sdtBuffer,
                 ErrBuffer: errBuffer,
         }
 }</span>
 
-func (c *Capturer) CaptureOutput(fnc func()) (string, string, error) <span class="cov8" title="1">{
+// CaptureOutput captures the output of a function.
+func (c *capturer) CaptureOutput(fnc func()) (string, string, error) <span class="cov8" title="1">{
         origStdout := os.Stdout
         origStderr := os.Stderr
         defer func() </span><span class="cov8" title="1">{
@@ -734,14 +788,17 @@ import (
         "github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// VersionUtil is an interface that provides the version of the application.
 type VersionUtil interface {
         GetVersion(version string) string
 }
 
+// versionUtil is a struct that implements the VersionUtil interface.
 type versionUtil struct {
         Debug proxy.Debug
 }
 
+// NewVersionUtil returns a new instance of the versionUtil struct.
 func NewVersionUtil(
         debug proxy.Debug,
 ) VersionUtil <span class="cov8" title="1">{
@@ -750,6 +807,7 @@ func NewVersionUtil(
         }
 }</span>
 
+// GetVersion returns the version of the application.
 func (v *versionUtil) GetVersion(version string) string <span class="cov8" title="1">{
         // if version is embedded, return it
         if version != "" </span><span class="cov8" title="1">{
@@ -758,8 +816,10 @@ func (v *versionUtil) GetVersion(version string) string <span class="cov8" title
 
         <span class="cov8" title="1">if i, ok := v.Debug.ReadBuildInfo(); !ok </span><span class="cov8" title="1">{
                 return "unknown"
-        }</span> else<span class="cov8" title="1"> {
+        }</span> else<span class="cov8" title="1"> if i.Main.Version != "" </span><span class="cov8" title="1">{
                 return i.Main.Version
+        }</span> else<span class="cov8" title="1"> {
+                return "dev"
         }</span>
 }
 </pre>

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,11 +2,13 @@ package errors
 
 import "fmt"
 
+// wrappedError is a struct that wraps an error and a message
 type wrappedError struct {
 	err error
 	msg string
 }
 
+// Error returns the error message formatted as a string
 func (e *wrappedError) Error() string {
 	if e.err == nil && e.msg == "" {
 		return ""
@@ -19,10 +21,12 @@ func (e *wrappedError) Error() string {
 	}
 }
 
+// New returns a new error with the given message
 func New(msg string) error {
 	return &wrappedError{msg: msg}
 }
 
+// Wrap returns a new error that wraps the given error with the given message
 func Wrap(err error, msg string) error {
 	return &wrappedError{
 		err: err,

--- a/pkg/proxy/buffer.go
+++ b/pkg/proxy/buffer.go
@@ -5,28 +5,34 @@ import (
 	"io"
 )
 
+// Buffer is an interface that provides a proxy of the methods of bytes.Buffer.
 type Buffer interface {
 	ReadFrom(r io.Reader) (int64, error)
 	Reset()
 	String() string
 }
 
+// bufferProxy is a proxy struct that implements the Buffer interface.
 type bufferProxy struct {
 	bytes.Buffer
 }
 
+// NewBuffer returns a new instance of the Buffer interface.
 func NewBuffer() Buffer {
 	return &bufferProxy{}
 }
 
+// ReadFrom is a proxy method that calls the ReadFrom method of the bytes.Buffer.
 func (b *bufferProxy) ReadFrom(r io.Reader) (int64, error) {
 	return b.Buffer.ReadFrom(r)
 }
 
+// Reset is a proxy method that calls the Reset method of the bytes.Buffer.
 func (b *bufferProxy) Reset() {
 	b.Buffer.Reset()
 }
 
+// String is a proxy method that calls the String method of the bytes.Buffer.
 func (b *bufferProxy) String() string {
 	return b.Buffer.String()
 }

--- a/pkg/proxy/cobra.go
+++ b/pkg/proxy/cobra.go
@@ -6,42 +6,52 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Cobra is an interface that provides a proxy of the methods of cobra
 type Cobra interface {
 	ExactArgs(int) PositionalArgs
 	MaximumNArgs(int) PositionalArgs
 	NewCommand() Command
 }
 
+// cobraProxy is a proxy struct that implements the Cobra interface.
 type cobraProxy struct{}
 
+// NewCobra returns a new instance of the Cobra interface.
 func NewCobra() Cobra {
 	return &cobraProxy{}
 }
 
+// ExactArgs is a proxy method that calls the ExactArgs method of the cobra.ExactArgs.
 func (*cobraProxy) ExactArgs(n int) PositionalArgs {
 	return &positionalArgsProxy{PositionalArgs: cobra.ExactArgs(n)}
 }
 
+// MaximumNArgs is a proxy method that calls the MaximumNArgs method of the cobra.MaximumNArgs.
 func (*cobraProxy) MaximumNArgs(n int) PositionalArgs {
 	return &positionalArgsProxy{PositionalArgs: cobra.MaximumNArgs(n)}
 }
 
+// NewCommand returns a new instance of the Command interface.
 func (*cobraProxy) NewCommand() Command {
 	return &commandProxy{Command: &cobra.Command{}}
 }
 
+// PositionalArgs is an interface that provides a proxy of the methods of cobra.PositionalArgs.
 type PositionalArgs interface {
 	GetPositionalArgs() cobra.PositionalArgs
 }
 
+// positionalArgsProxy is a proxy struct that implements the PositionalArgs interface.
 type positionalArgsProxy struct {
 	PositionalArgs cobra.PositionalArgs
 }
 
+// GetPositionalArgs is a proxy method that calls the GetPositionalArgs method of the cobra.PositionalArgs.
 func (p *positionalArgsProxy) GetPositionalArgs() cobra.PositionalArgs {
 	return p.PositionalArgs
 }
 
+// Command is an interface that provides a proxy of the methods of cobra.Command.
 type Command interface {
 	AddCommand(cmds ...Command)
 	Execute() error
@@ -60,68 +70,84 @@ type Command interface {
 	SetVersion(version string)
 }
 
+// commandProxy is a proxy struct that implements the Command interface.
 type commandProxy struct {
 	Command *cobra.Command
 }
 
+// AddCommand is a proxy method that calls the AddCommand method of the cobra.Command.
 func (c *commandProxy) AddCommand(cmds ...Command) {
 	for _, cmd := range cmds {
 		c.Command.AddCommand(cmd.GetCommand())
 	}
 }
 
+// Execute is a proxy method that calls the Execute method of the cobra.Command.
 func (c *commandProxy) Execute() error {
 	return c.Command.Execute()
 }
 
+// GetCommand is a proxy method that calls the GetCommand method of the cobra.Command.
 func (c *commandProxy) GetCommand() *cobra.Command {
 	return c.Command
 }
 
+// PersistentFlags is a proxy method that calls the PersistentFlags method of the cobra.Command.
 func (c *commandProxy) PersistentFlags() FlagSet {
 	return &flagSetProxy{FlagSet: c.Command.PersistentFlags()}
 }
 
+// RunE is a proxy method that calls the RunE method of the cobra.Command.
 func (c *commandProxy) RunE(cmd *cobra.Command, args []string) error {
 	return c.Command.RunE(cmd, args)
 }
 
+// SetArgs is a proxy method that calls the SetArgs method of the cobra.Command.
 func (c *commandProxy) SetArgs(positionalArgs PositionalArgs) {
 	c.Command.Args = positionalArgs.GetPositionalArgs()
 }
 
+// SetErr is a proxy method that calls the SetErr method of the cobra.Command.
 func (c *commandProxy) SetErr(io io.Writer) {
 	c.Command.SetErr(io)
 }
 
+// SetHelpTemplate is a proxy method that calls the SetHelpTemplate method of the cobra.Command.
 func (c *commandProxy) SetHelpTemplate(s string) {
 	c.Command.SetHelpTemplate(s)
 }
 
+// SetMaximumNArgs is a proxy method that calls the SetMaximumNArgs method of the cobra.Command.
 func (c *commandProxy) SetMaximumNArgs(n int) {
 	c.Command.Args = cobra.MaximumNArgs(n)
 }
 
+// SetOut is a proxy method that calls the SetOut method of the cobra.Command.
 func (c *commandProxy) SetOut(io io.Writer) {
 	c.Command.SetOut(io)
 }
 
+// SetRunE is a proxy method that calls the SetRunE method of the cobra.Command.
 func (c *commandProxy) SetRunE(runE func(cmd *cobra.Command, args []string) error) {
 	c.Command.RunE = runE
 }
 
+// SetSilenceErrors is a proxy method that calls the SetSilenceErrors method of the cobra.Command.
 func (c *commandProxy) SetSilenceErrors(silenceErrors bool) {
 	c.Command.SilenceErrors = silenceErrors
 }
 
+// SetUse is a proxy method that calls the SetUse method of the cobra.Command.
 func (c *commandProxy) SetUse(use string) {
 	c.Command.Use = use
 }
 
+// SetUsageTemplate is a proxy method that calls the SetUsageTemplate method of the cobra.Command.
 func (c *commandProxy) SetUsageTemplate(s string) {
 	c.Command.SetUsageTemplate(s)
 }
 
+// SetVersion is a proxy method that calls the SetVersion method of the cobra.Command.
 func (c *commandProxy) SetVersion(version string) {
 	c.Command.Version = version
 }

--- a/pkg/proxy/debug.go
+++ b/pkg/proxy/debug.go
@@ -4,16 +4,20 @@ import (
 	"runtime/debug"
 )
 
+// Debug is an interface that provides a proxy of the methods of debug.
 type Debug interface {
 	ReadBuildInfo() (info *debug.BuildInfo, ok bool)
 }
 
+// debugProxy is a proxy struct that implements the Debug interface.
 type debugProxy struct{}
 
+// NewDebug returns a new instance of the Debug interface.
 func NewDebug() Debug {
 	return &debugProxy{}
 }
 
+// ReadBuildInfo is a proxy method that calls the ReadBuildInfo method of the debug.
 func (*debugProxy) ReadBuildInfo() (info *debug.BuildInfo, ok bool) {
 	return debug.ReadBuildInfo()
 }

--- a/pkg/proxy/pflag.go
+++ b/pkg/proxy/pflag.go
@@ -4,14 +4,17 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// FlagSet is an interface that provides a proxy of the methods of pflag.FlagSet.
 type FlagSet interface {
 	StringVarP(p *string, name string, shorthand string, value string, usage string)
 }
 
+// flagSetProxy is a proxy struct that implements the FlagSet interface.
 type flagSetProxy struct {
 	FlagSet *pflag.FlagSet
 }
 
+// NewFlagSet returns a new instance of the FlagSet interface.
 func (f *flagSetProxy) StringVarP(p *string, name string, shorthand string, value string, usage string) {
 	f.FlagSet.StringVarP(p, name, shorthand, value, usage)
 }

--- a/pkg/utility/capture.go
+++ b/pkg/utility/capture.go
@@ -6,25 +6,32 @@ import (
 	"github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// Capturable is an interface that captures the output of a function.
 type Capturable interface {
+	CaptureOutput(fnc func()) (string, string, error)
 }
 
-type Capturer struct {
+// capturer is a struct that implements the Capturable interface.
+type capturer struct {
+	// StdBuffer is a buffer for standard output.
 	StdBuffer proxy.Buffer
+	// ErrBuffer is a buffer for error output.
 	ErrBuffer proxy.Buffer
 }
 
+// NewCapturer returns a new instance of the capturer struct.
 func NewCapturer(
 	sdtBuffer proxy.Buffer,
 	errBuffer proxy.Buffer,
-) *Capturer {
-	return &Capturer{
+) *capturer {
+	return &capturer{
 		StdBuffer: sdtBuffer,
 		ErrBuffer: errBuffer,
 	}
 }
 
-func (c *Capturer) CaptureOutput(fnc func()) (string, string, error) {
+// CaptureOutput captures the output of a function.
+func (c *capturer) CaptureOutput(fnc func()) (string, string, error) {
 	origStdout := os.Stdout
 	origStderr := os.Stderr
 	defer func() {

--- a/pkg/utility/capture_test.go
+++ b/pkg/utility/capture_test.go
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *Capturer
+		want *capturer
 	}{
 		{
 			name: "positive case",
@@ -31,7 +31,7 @@ func TestNew(t *testing.T) {
 				sdtBuffer: stdBuffer,
 				errBuffer: errBuffer,
 			},
-			want: &Capturer{
+			want: &capturer{
 				StdBuffer: stdBuffer,
 				ErrBuffer: errBuffer,
 			},
@@ -136,7 +136,7 @@ func TestCapturer_CaptureOutput(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(mockCtrl, &tt.fields)
 			}
-			c := &Capturer{
+			c := &capturer{
 				StdBuffer: tt.fields.StdBuffer,
 				ErrBuffer: tt.fields.ErrBuffer,
 			}

--- a/pkg/utility/version_util.go
+++ b/pkg/utility/version_util.go
@@ -4,14 +4,17 @@ import (
 	"github.com/yanosea/mindnum/pkg/proxy"
 )
 
+// VersionUtil is an interface that provides the version of the application.
 type VersionUtil interface {
 	GetVersion(version string) string
 }
 
+// versionUtil is a struct that implements the VersionUtil interface.
 type versionUtil struct {
 	Debug proxy.Debug
 }
 
+// NewVersionUtil returns a new instance of the versionUtil struct.
 func NewVersionUtil(
 	debug proxy.Debug,
 ) VersionUtil {
@@ -20,6 +23,7 @@ func NewVersionUtil(
 	}
 }
 
+// GetVersion returns the version of the application.
 func (v *versionUtil) GetVersion(version string) string {
 	// if version is embedded, return it
 	if version != "" {

--- a/pkg/utility/version_util.go
+++ b/pkg/utility/version_util.go
@@ -28,7 +28,9 @@ func (v *versionUtil) GetVersion(version string) string {
 
 	if i, ok := v.Debug.ReadBuildInfo(); !ok {
 		return "unknown"
-	} else {
+	} else if i.Main.Version != "" {
 		return i.Main.Version
+	} else {
+		return "dev"
 	}
 }

--- a/pkg/utility/version_util_test.go
+++ b/pkg/utility/version_util_test.go
@@ -66,7 +66,25 @@ func Test_versionUtil_GetVersion(t *testing.T) {
 			setup: nil,
 		},
 		{
-			name: "positive case (version is empty, debug.ReadBuildInfo() returns true)",
+			name: "positive case (version is empty, debug.ReadBuildInfo() returns false)",
+			fields: fields{
+				debug: nil,
+			},
+			args: args{
+				version: "",
+			},
+			want: "unknown",
+			setup: func(mockCtrl *gomock.Controller, tt *fields) {
+				mockDebug := proxy.NewMockDebug(mockCtrl)
+				mockDebug.EXPECT().ReadBuildInfo().Return(
+					&debug.BuildInfo{},
+					false,
+				)
+				tt.debug = mockDebug
+			},
+		},
+		{
+			name: "positive case (version is empty, debug.ReadBuildInfo() returns true and i.Main.Version is not empty)",
 			fields: fields{
 				debug: nil,
 			},
@@ -87,20 +105,25 @@ func Test_versionUtil_GetVersion(t *testing.T) {
 				tt.debug = mockDebug
 			},
 		},
+
 		{
-			name: "positive case (version is empty, debug.ReadBuildInfo() returns false)",
+			name: "positive case (version is empty, debug.ReadBuildInfo() returns true, i.Main.Version is empty)",
 			fields: fields{
 				debug: nil,
 			},
 			args: args{
 				version: "",
 			},
-			want: "unknown",
+			want: "dev",
 			setup: func(mockCtrl *gomock.Controller, tt *fields) {
 				mockDebug := proxy.NewMockDebug(mockCtrl)
 				mockDebug.EXPECT().ReadBuildInfo().Return(
-					&debug.BuildInfo{},
-					false,
+					&debug.BuildInfo{
+						Main: debug.Module{
+							Version: "",
+						},
+					},
+					true,
 				)
 				tt.debug = mockDebug
 			},


### PR DESCRIPTION
- add handling for empty main version in debug build info
- return `dev` when main version is empty in build info
- update test cases to cover new version handling scenarios