### PR TITLE
🔨refactor: remove alias from os package import

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,6 +1,8 @@
 package errors
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // wrappedError is a struct that wraps an error and a message
 type wrappedError struct {

--- a/pkg/utility/capture_test.go
+++ b/pkg/utility/capture_test.go
@@ -3,7 +3,7 @@ package utility
 import (
 	"errors"
 	"fmt"
-	o "os"
+	"os"
 	"reflect"
 	"testing"
 
@@ -71,8 +71,8 @@ func TestCapturer_CaptureOutput(t *testing.T) {
 			},
 			args: args{
 				fnc: func() {
-					fmt.Fprint(o.Stdout, "stdout")
-					fmt.Fprint(o.Stderr, "stderr")
+					fmt.Fprint(os.Stdout, "stdout")
+					fmt.Fprint(os.Stderr, "stderr")
 				},
 			},
 			wantStdOut: "stdout",
@@ -88,8 +88,8 @@ func TestCapturer_CaptureOutput(t *testing.T) {
 			},
 			args: args{
 				fnc: func() {
-					fmt.Fprint(o.Stdout, "stdout")
-					fmt.Fprint(o.Stderr, "stderr")
+					fmt.Fprint(os.Stdout, "stdout")
+					fmt.Fprint(os.Stderr, "stderr")
 				},
 			},
 			wantStdOut: "",
@@ -112,8 +112,8 @@ func TestCapturer_CaptureOutput(t *testing.T) {
 			},
 			args: args{
 				fnc: func() {
-					fmt.Fprint(o.Stdout, "stdout")
-					fmt.Fprint(o.Stderr, "stderr")
+					fmt.Fprint(os.Stdout, "stdout")
+					fmt.Fprint(os.Stderr, "stderr")
 				},
 			},
 			wantStdOut: "",


### PR DESCRIPTION
- change import alias `o` to standard `os` import
  for better readability
- update all references from `o.Stdout` to `os.Stdout`
- update all references from `o.Stderr` to `os.Stderr`
- this change makes the code more straightforward
  and consistent with Go conventions