### PR TITLE
🐞fix: correct variable name typo from `sdt` to `std` in `capturer`

### DIFF
--- a/pkg/utility/capture.go
+++ b/pkg/utility/capture.go
@@ -21,11 +21,11 @@ type capturer struct {
 
 // NewCapturer returns a new instance of the capturer struct.
 func NewCapturer(
-	sdtBuffer proxy.Buffer,
+	stdBuffer proxy.Buffer,
 	errBuffer proxy.Buffer,
 ) *capturer {
 	return &capturer{
-		StdBuffer: sdtBuffer,
+		StdBuffer: stdBuffer,
 		ErrBuffer: errBuffer,
 	}
 }


### PR DESCRIPTION
- fix typo in variable name `sdtBuffer` to `stdBuffer` in `NewCapturer` function
- update corresponding struct field assignment to maintain consistency