### PR TITLE
✨feat: add aliases to get command and improve usage format

### DIFF
--- a/app/presentation/cli/mindnum/command/mindnum/get.go
+++ b/app/presentation/cli/mindnum/command/mindnum/get.go
@@ -24,6 +24,7 @@ func NewGetCommand(
 	cmd := cobra.NewCommand()
 	cmd.SetSilenceErrors(true)
 	cmd.SetUse("get [birthday (optional)]")
+	cmd.SetAliases([]string{"gt", "g"})
 	cmd.SetUsageTemplate(getUsageTemplate)
 	cmd.SetHelpTemplate(getHelpTemplate)
 	cmd.PersistentFlags().StringVarP(
@@ -74,7 +75,7 @@ const (
 ` + getUsageTemplate
 	// getUsageTemplate is the usage template of the get command.
 	getUsageTemplate = `Usage:
-  mindnum get [birthday (optional)] [flags]
+  mindnum get [flags] [argument]
 
 Flags:
   -b, --birthday string  🎂 birthday in the format 'yyyyMMdd' (e.g. 19900719) (optional)

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -351,6 +351,7 @@ func NewGetCommand(
         cmd := cobra.NewCommand()
         cmd.SetSilenceErrors(true)
         cmd.SetUse("get [birthday (optional)]")
+        cmd.SetAliases([]string{"gt", "g"})
         cmd.SetUsageTemplate(getUsageTemplate)
         cmd.SetHelpTemplate(getHelpTemplate)
         cmd.PersistentFlags().StringVarP(
@@ -401,7 +402,7 @@ const (
 ` + getUsageTemplate
         // getUsageTemplate is the usage template of the get command.
         getUsageTemplate = `Usage:
-  mindnum get [birthday (optional)] [flags]
+  mindnum get [flags] [argument]
 
 Flags:
   -b, --birthday string  🎂 birthday in the format 'yyyyMMdd' (e.g. 19900719) (optional)
@@ -678,7 +679,9 @@ func Present(writer io.Writer, output string) <span class="cov8" title="1">{
 		
 		<pre class="file" id="file12" style="display: none">package errors
 
-import "fmt"
+import (
+        "fmt"
+)
 
 // wrappedError is a struct that wraps an error and a message
 type wrappedError struct {
@@ -736,11 +739,11 @@ type capturer struct {
 
 // NewCapturer returns a new instance of the capturer struct.
 func NewCapturer(
-        sdtBuffer proxy.Buffer,
+        stdBuffer proxy.Buffer,
         errBuffer proxy.Buffer,
 ) *capturer <span class="cov8" title="1">{
         return &amp;capturer{
-                StdBuffer: sdtBuffer,
+                StdBuffer: stdBuffer,
                 ErrBuffer: errBuffer,
         }
 }</span>

--- a/pkg/proxy/cobra.go
+++ b/pkg/proxy/cobra.go
@@ -58,6 +58,7 @@ type Command interface {
 	GetCommand() *cobra.Command
 	PersistentFlags() FlagSet
 	RunE(cmd *cobra.Command, args []string) error
+	SetAliases(aliases []string)
 	SetArgs(positionalArgs PositionalArgs)
 	SetErr(io io.Writer)
 	SetHelpTemplate(s string)
@@ -100,6 +101,11 @@ func (c *commandProxy) PersistentFlags() FlagSet {
 // RunE is a proxy method that calls the RunE method of the cobra.Command.
 func (c *commandProxy) RunE(cmd *cobra.Command, args []string) error {
 	return c.Command.RunE(cmd, args)
+}
+
+// SetAliases is a proxy method that calls the SetAliases method of the cobra.Command.
+func (c *commandProxy) SetAliases(aliases []string) {
+	c.Command.Aliases = aliases
 }
 
 // SetArgs is a proxy method that calls the SetArgs method of the cobra.Command.

--- a/pkg/proxy/cobra_mock.go
+++ b/pkg/proxy/cobra_mock.go
@@ -214,6 +214,18 @@ func (mr *MockCommandMockRecorder) RunE(cmd, args any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunE", reflect.TypeOf((*MockCommand)(nil).RunE), cmd, args)
 }
 
+// SetAliases mocks base method.
+func (m *MockCommand) SetAliases(aliases []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAliases", aliases)
+}
+
+// SetAliases indicates an expected call of SetAliases.
+func (mr *MockCommandMockRecorder) SetAliases(aliases any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAliases", reflect.TypeOf((*MockCommand)(nil).SetAliases), aliases)
+}
+
 // SetArgs mocks base method.
 func (m *MockCommand) SetArgs(positionalArgs PositionalArgs) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- add `gt` and `g` as aliases for get command
- change the order of arguments and flags in usage template
- update command interface to support aliases
- update cobra proxy and mock to implement `SetAliases` method