### PR TITLE
👷chore: upgrade Go version from 1.23 to 1.24.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ on:
       - "master"
 
 env:
-  GO_VERSION: 1.23.x
+  GO_VERSION: 1.24.x
   GOLANGCI_LINT_VERSION: v2.0
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/CREDITS
+++ b/CREDITS
@@ -1,7 +1,7 @@
 Go (the standard library)
 https://golang.org/
 ----------------------------------------------------------------
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -13,7 +13,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanosea/mindnum
 
-go 1.23
+go 1.24.1
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
- update Go version in `go.mod` to use the latest stable release
- ensure compatibility with Go `1.24.1` features and improvements