### PR TITLE
👷chore: update module path to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Flags:
 ### 🐭 Using go
 
 ```
-go install github.com/yanosea/mindnum/app/presentation/cli/mindnum@latest 
+go install github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum@latest 
 ```
 
 ### 🍺 Using homebrew
@@ -75,7 +75,7 @@ Go to the [Releases](https://github.com/yanosea/mindnum/releases) and download t
 Reinstall `mindnum`!
 
 ```
-go install github.com/yanosea/mindnum/app/presentation/cli/mindnum@latest 
+go install github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum@latest 
 ```
 
 ### 🍺 Using homebrew

--- a/app/application/mindnum/get_mindnum_usecase.go
+++ b/app/application/mindnum/get_mindnum_usecase.go
@@ -1,7 +1,7 @@
 package mindnum
 
 import (
-	mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
+	mindnumDomain "github.com/yanosea/mindnum/v2/app/domain/mindnum"
 )
 
 // GetMindnumUseCase is a struct that provides the use case of getting a mind number.

--- a/app/application/mindnum/get_mindnum_usecase_test.go
+++ b/app/application/mindnum/get_mindnum_usecase_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
-	mindnumRepo "github.com/yanosea/mindnum/app/infrastructure/text/repository"
+	mindnumDomain "github.com/yanosea/mindnum/v2/app/domain/mindnum"
+	mindnumRepo "github.com/yanosea/mindnum/v2/app/infrastructure/text/repository"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/infrastructure/text/repository/mindnum_repository.go
+++ b/app/infrastructure/text/repository/mindnum_repository.go
@@ -3,7 +3,7 @@ package repository
 import (
 	"errors"
 
-	mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
+	mindnumDomain "github.com/yanosea/mindnum/v2/app/domain/mindnum"
 )
 
 // mindnumRepository is a struct that implements the MindnumRepository interface.

--- a/app/infrastructure/text/repository/mindnum_repository_test.go
+++ b/app/infrastructure/text/repository/mindnum_repository_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
+	mindnumDomain "github.com/yanosea/mindnum/v2/app/domain/mindnum"
 )
 
 func TestNewMindnumRepository(t *testing.T) {

--- a/app/presentation/cli/mindnum/command/command.go
+++ b/app/presentation/cli/mindnum/command/command.go
@@ -3,10 +3,10 @@ package command
 import (
 	"os"
 
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter"
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/presenter"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/presenter"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // Cli is a struct that represents the command line interface of mindnum cli.

--- a/app/presentation/cli/mindnum/command/command_test.go
+++ b/app/presentation/cli/mindnum/command/command_test.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/presenter"
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/presenter"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/mindnum/command/mindnum/get.go
+++ b/app/presentation/cli/mindnum/command/mindnum/get.go
@@ -3,11 +3,11 @@ package mindnum
 import (
 	c "github.com/spf13/cobra"
 
-	mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
-	mindnumRepo "github.com/yanosea/mindnum/app/infrastructure/text/repository"
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter"
+	mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
+	mindnumRepo "github.com/yanosea/mindnum/v2/app/infrastructure/text/repository"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 var (

--- a/app/presentation/cli/mindnum/command/mindnum/get_test.go
+++ b/app/presentation/cli/mindnum/command/mindnum/get_test.go
@@ -3,7 +3,7 @@ package mindnum
 import (
 	"testing"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 func TestNewGetCommand(t *testing.T) {

--- a/app/presentation/cli/mindnum/command/mindnum/version.go
+++ b/app/presentation/cli/mindnum/command/mindnum/version.go
@@ -3,10 +3,10 @@ package mindnum
 import (
 	c "github.com/spf13/cobra"
 
-	mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter"
+	mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // NewVersionCommand returns a new instance of the version command.

--- a/app/presentation/cli/mindnum/command/mindnum/version_test.go
+++ b/app/presentation/cli/mindnum/command/mindnum/version_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 func TestNewVersionCommand(t *testing.T) {

--- a/app/presentation/cli/mindnum/command/root.go
+++ b/app/presentation/cli/mindnum/command/root.go
@@ -1,9 +1,9 @@
 package command
 
 import (
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/command/mindnum"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command/mindnum"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // NewRootCommand returns a new instance of the root command.

--- a/app/presentation/cli/mindnum/command/root_test.go
+++ b/app/presentation/cli/mindnum/command/root_test.go
@@ -3,7 +3,7 @@ package command
 import (
 	"testing"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 func TestNewRootCommand(t *testing.T) {

--- a/app/presentation/cli/mindnum/formatter/text.go
+++ b/app/presentation/cli/mindnum/formatter/text.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
+	mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
 )
 
 // TextFormatter is a struct that formats the output of mindnum cli.

--- a/app/presentation/cli/mindnum/formatter/text_test.go
+++ b/app/presentation/cli/mindnum/formatter/text_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
+	mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
 )
 
 func TestNewTextFormatter(t *testing.T) {

--- a/app/presentation/cli/mindnum/main.go
+++ b/app/presentation/cli/mindnum/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"os"
 
-	"github.com/yanosea/mindnum/app/presentation/cli/mindnum/command"
+	"github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
-	"github.com/yanosea/mindnum/pkg/utility"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/utility"
 )
 
 var (

--- a/app/presentation/cli/mindnum/main_test.go
+++ b/app/presentation/cli/mindnum/main_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
-	mindnumRepo "github.com/yanosea/mindnum/app/infrastructure/text/repository"
+	mindnumRepo "github.com/yanosea/mindnum/v2/app/infrastructure/text/repository"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
-	"github.com/yanosea/mindnum/pkg/utility"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/utility"
 )
 
 func Test_main(t *testing.T) {

--- a/app/presentation/cli/mindnum/presenter/presenter_test.go
+++ b/app/presentation/cli/mindnum/presenter/presenter_test.go
@@ -4,8 +4,8 @@ import (
 	o "os"
 	"testing"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
-	"github.com/yanosea/mindnum/pkg/utility"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/utility"
 )
 
 func TestPrint(t *testing.T) {

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -55,33 +55,33 @@
 			<div id="nav">
 				<select id="files">
 				
-				<option value="file0">github.com/yanosea/mindnum/app/application/mindnum/get_mindnum_usecase.go (100.0%)</option>
+				<option value="file0">github.com/yanosea/mindnum/v2/app/application/mindnum/get_mindnum_usecase.go (100.0%)</option>
 				
-				<option value="file1">github.com/yanosea/mindnum/app/application/mindnum/version_usecase.go (100.0%)</option>
+				<option value="file1">github.com/yanosea/mindnum/v2/app/application/mindnum/version_usecase.go (100.0%)</option>
 				
-				<option value="file2">github.com/yanosea/mindnum/app/domain/mindnum/mindnum_model.go (100.0%)</option>
+				<option value="file2">github.com/yanosea/mindnum/v2/app/domain/mindnum/mindnum_model.go (100.0%)</option>
 				
-				<option value="file3">github.com/yanosea/mindnum/app/infrastructure/text/repository/mindnum_repository.go (100.0%)</option>
+				<option value="file3">github.com/yanosea/mindnum/v2/app/infrastructure/text/repository/mindnum_repository.go (100.0%)</option>
 				
-				<option value="file4">github.com/yanosea/mindnum/app/presentation/cli/mindnum/command/command.go (100.0%)</option>
+				<option value="file4">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command/command.go (100.0%)</option>
 				
-				<option value="file5">github.com/yanosea/mindnum/app/presentation/cli/mindnum/command/mindnum/get.go (100.0%)</option>
+				<option value="file5">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command/mindnum/get.go (100.0%)</option>
 				
-				<option value="file6">github.com/yanosea/mindnum/app/presentation/cli/mindnum/command/mindnum/version.go (100.0%)</option>
+				<option value="file6">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command/mindnum/version.go (100.0%)</option>
 				
-				<option value="file7">github.com/yanosea/mindnum/app/presentation/cli/mindnum/command/root.go (100.0%)</option>
+				<option value="file7">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command/root.go (100.0%)</option>
 				
-				<option value="file8">github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter/formatter.go (100.0%)</option>
+				<option value="file8">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter/formatter.go (100.0%)</option>
 				
-				<option value="file9">github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter/text.go (100.0%)</option>
+				<option value="file9">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter/text.go (100.0%)</option>
 				
-				<option value="file10">github.com/yanosea/mindnum/app/presentation/cli/mindnum/main.go (100.0%)</option>
+				<option value="file10">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/main.go (100.0%)</option>
 				
-				<option value="file11">github.com/yanosea/mindnum/app/presentation/cli/mindnum/presenter/presenter.go (100.0%)</option>
+				<option value="file11">github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/presenter/presenter.go (100.0%)</option>
 				
-				<option value="file12">github.com/yanosea/mindnum/pkg/utility/capture.go (100.0%)</option>
+				<option value="file12">github.com/yanosea/mindnum/v2/pkg/utility/capture.go (100.0%)</option>
 				
-				<option value="file13">github.com/yanosea/mindnum/pkg/utility/version_util.go (100.0%)</option>
+				<option value="file13">github.com/yanosea/mindnum/v2/pkg/utility/version_util.go (100.0%)</option>
 				
 				</select>
 			</div>
@@ -98,7 +98,7 @@
 		<pre class="file" id="file0" style="display: none">package mindnum
 
 import (
-        mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
+        mindnumDomain "github.com/yanosea/mindnum/v2/app/domain/mindnum"
 )
 
 // GetMindnumUseCase is a struct that provides the use case of getting a mind number.
@@ -226,7 +226,7 @@ func GetMindNumber(birthday string) (int, error) <span class="cov8" title="1">{
 import (
         "errors"
 
-        mindnumDomain "github.com/yanosea/mindnum/app/domain/mindnum"
+        mindnumDomain "github.com/yanosea/mindnum/v2/app/domain/mindnum"
 )
 
 // mindnumRepository is a struct that implements the MindnumRepository interface.
@@ -272,10 +272,10 @@ func (r *mindnumRepository) FindByNumber(number int) (*mindnumDomain.Mindnum, er
 import (
         "os"
 
-        "github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter"
-        "github.com/yanosea/mindnum/app/presentation/cli/mindnum/presenter"
+        "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter"
+        "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/presenter"
 
-        "github.com/yanosea/mindnum/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // Cli is a struct that represents the command line interface of mindnum cli.
@@ -329,11 +329,11 @@ func (c *Cli) Run() int <span class="cov8" title="1">{
 import (
         c "github.com/spf13/cobra"
 
-        mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
-        mindnumRepo "github.com/yanosea/mindnum/app/infrastructure/text/repository"
-        "github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter"
+        mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
+        mindnumRepo "github.com/yanosea/mindnum/v2/app/infrastructure/text/repository"
+        "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter"
 
-        "github.com/yanosea/mindnum/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 var (
@@ -418,10 +418,10 @@ Arguments:
 import (
         c "github.com/spf13/cobra"
 
-        mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
-        "github.com/yanosea/mindnum/app/presentation/cli/mindnum/formatter"
+        mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
+        "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/formatter"
 
-        "github.com/yanosea/mindnum/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // NewVersionCommand returns a new instance of the version command.
@@ -481,9 +481,9 @@ Flags:
 		<pre class="file" id="file7" style="display: none">package command
 
 import (
-        "github.com/yanosea/mindnum/app/presentation/cli/mindnum/command/mindnum"
+        "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command/mindnum"
 
-        "github.com/yanosea/mindnum/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // NewRootCommand returns a new instance of the root command.
@@ -598,7 +598,7 @@ import (
         "fmt"
         "strings"
 
-        mindnumApp "github.com/yanosea/mindnum/app/application/mindnum"
+        mindnumApp "github.com/yanosea/mindnum/v2/app/application/mindnum"
 )
 
 // TextFormatter is a struct that formats the output of mindnum cli.
@@ -634,10 +634,10 @@ func (f *TextFormatter) Format(result interface{}) string <span class="cov8" tit
 import (
         "os"
 
-        "github.com/yanosea/mindnum/app/presentation/cli/mindnum/command"
+        "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum/command"
 
-        "github.com/yanosea/mindnum/pkg/proxy"
-        "github.com/yanosea/mindnum/pkg/utility"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/utility"
 )
 
 var (
@@ -688,7 +688,7 @@ var Print PrintFunc = func(writer io.Writer, output string) error <span class="c
 import (
         "os"
 
-        "github.com/yanosea/mindnum/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // Capturer is an interface that captures the output of a function.
@@ -769,7 +769,7 @@ func (c *capturer) CaptureOutput(fnc func()) (string, string, error) <span class
 		<pre class="file" id="file13" style="display: none">package utility
 
 import (
-        "github.com/yanosea/mindnum/pkg/proxy"
+        "github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // VersionUtil is an interface that provides the version of the application.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yanosea/mindnum
+module github.com/yanosea/mindnum/v2
 
 go 1.24.1
 

--- a/pkg/utility/capture.go
+++ b/pkg/utility/capture.go
@@ -3,7 +3,7 @@ package utility
 import (
 	"os"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // Capturer is an interface that captures the output of a function.

--- a/pkg/utility/capture_test.go
+++ b/pkg/utility/capture_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/utility/version_util.go
+++ b/pkg/utility/version_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 )
 
 // VersionUtil is an interface that provides the version of the application.

--- a/pkg/utility/version_util_test.go
+++ b/pkg/utility/version_util_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 	"testing"
 
-	"github.com/yanosea/mindnum/pkg/proxy"
+	"github.com/yanosea/mindnum/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )


### PR DESCRIPTION
- change module path from `github.com/yanosea/mindnum` to `github.com/yanosea/mindnum/v2`
- update all import paths across the project to reflect the new module path
- update `go.mod` file to use the new module name
- this change follows Go Modules convention for major version upgrades, which requires including the version in the module path for v2+