### PR TITLE
(goreleaser) fix deprecated configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,18 +19,20 @@ builds:
       - -X main.version=v{{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{- else if eq .Arch "386" }}i386 {{- else }}{{ .Arch }}{{ end }} {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -43,7 +45,7 @@ changelog:
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-brews:
+homebrew_casks:
   - repository:
       owner: yanosea
       name: homebrew-tap


### PR DESCRIPTION
- replace `archives.format` with `archives.formats`
- replace `archives.format_overrides.format` with `archives.format_overrides.formats`
- rename `snapshot.name_template` to `snapshot.version_template`
- migrate `brews` to `homebrew_casks`

closes #75