### PR TITLE
🧹chore(workflow): update go and golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,8 +8,8 @@ on:
       - "master"
 
 env:
-  GO_VERSION: 1.25.x
-  GOLANGCI_LINT_VERSION: v2.8
+  GO_VERSION: 1.26.x
+  GOLANGCI_LINT_VERSION: v2.11
 
 jobs:
   detect-modules:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/app/presentation/cli/mindnum/formatter/text.go
+++ b/app/presentation/cli/mindnum/formatter/text.go
@@ -23,7 +23,7 @@ func (f *TextFormatter) Format(result interface{}) string {
 		formatted = fmt.Sprintf("mindnum version %s", v.Version)
 	case *mindnumApp.GetMindnumUsecaseOutputDto:
 		var builder strings.Builder
-		builder.WriteString(fmt.Sprintf("Your mind number is %d!", v.MindNumber))
+		fmt.Fprintf(&builder, "Your mind number is %d!", v.MindNumber)
 		if trimmedDescription := strings.TrimSpace(v.Description); trimmedDescription != "" {
 			builder.WriteString("\n\n")
 			builder.WriteString(trimmedDescription)

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -617,7 +617,7 @@ func (f *TextFormatter) Format(result interface{}) string <span class="cov8" tit
                 formatted = fmt.Sprintf("mindnum version %s", v.Version)</span>
         case *mindnumApp.GetMindnumUsecaseOutputDto:<span class="cov8" title="1">
                 var builder strings.Builder
-                builder.WriteString(fmt.Sprintf("Your mind number is %d!", v.MindNumber))
+                fmt.Fprintf(&amp;builder, "Your mind number is %d!", v.MindNumber)
                 if trimmedDescription := strings.TrimSpace(v.Description); trimmedDescription != "" </span><span class="cov8" title="1">{
                         builder.WriteString("\n\n")
                         builder.WriteString(trimmedDescription)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanosea/mindnum/v2
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
- bump `go` from `1.25.x` to `1.26.x`
- bump `golangci-lint` from `v2.8` to `v2.11`
- update `go.mod` to `go 1.26.1`

closes #81